### PR TITLE
arguments as xml file for wsmancli invoke

### DIFF
--- a/wsman/provider/wsmancli.py
+++ b/wsman/provider/wsmancli.py
@@ -745,10 +745,13 @@ class WSManCLI(WSManProvider):
                     else:
                         input_file.write('<p:%s>%s</p:%s>\n' % (k, v, k))
                 input_file.write('</p:%s_INPUT>\n' % command)
+                input_file.seek(0)
                 get_command += '--input \"%s\" ' % input_file.name
 
             log.debug ("Executing command %s" % get_command)
+            log.debug ("XML input file %s content:\n%s" % (input_file.name, input_file.read()))
             output = self.get_transport().execute(get_command)
+
             if input_file:
                 input_file.close()
 


### PR DESCRIPTION
Hi,

I modified invoke method to pass xml file instead of single parameters to wsman command. I found that this is the only way to pass multiple parameters with the same key, eg. VDPropNameArray and VDPropValueArray pairs or PDArray. With this modification I can pass dict with key PDArray and value as list: ['Disk.Bay.12:Enclosure.Internal.0-1:RAID.Integrated.1-1', 'Disk.Bay.13:Enclosure.Internal.0-1:RAID.Integrated.1-1']
I hope you'll find it useful.

Kamil
